### PR TITLE
兼容dGPU和Jetson，修复帧缓冲指针选择与memType适配问题

### DIFF
--- a/src/NvMOTContext.cpp
+++ b/src/NvMOTContext.cpp
@@ -120,8 +120,17 @@ NvMOTContext::processFrame(const NvMOTProcessParams *params,
         }
 
         NvBufSurfaceParams *bufferParams = frame->bufferList[0];
+        // NVBUF_MEM_SURFACE_ARRAY 时 dataPtr 不可直接使用，优先用 mappedAddr
+        void *rgbaPtr = bufferParams->mappedAddr.addr[0] != nullptr
+                            ? bufferParams->mappedAddr.addr[0]
+                            : bufferParams->dataPtr;
+        if (rgbaPtr == nullptr)
+        {
+            std::cerr << "Invalid RGBA buffer pointer (dataPtr/mappedAddr is null)" << std::endl;
+            continue;
+        }
         cv::Mat rgbaFrame(bufferParams->height, bufferParams->width, CV_8UC4,
-                          bufferParams->dataPtr);
+                          rgbaPtr, bufferParams->pitch);
         cv::Mat bgrFrame;
         // 跟踪器输入为 3 通道 BGR，DeepStream 输出为 RGBA，需要转换
         cv::cvtColor(rgbaFrame, bgrFrame, cv::COLOR_RGBA2BGR);

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -380,7 +380,11 @@ NvMOTStatus NvMOT_Query(uint16_t customConfigFilePathSize,
     /**  所有自定义跟踪器的必需配置。 */
     pQuery->computeConfig = NVMOTCOMP_CPU; // among {NVMOTCOMP_GPU, NVMOTCOMP_CPU}
     pQuery->numTransforms = 1;             // 0 for IOU and NvSORT tracker, 1 for NvDCF or NvDeepSORT tracker as they require the video frames
+#ifdef __aarch64__
+    pQuery->memType = NVBUF_MEM_SURFACE_ARRAY;
+#else
     pQuery->memType = NVBUF_MEM_CUDA_UNIFIED;
+#endif
     pQuery->batchMode = NvMOTBatchMode_Batch;          // batchMode must be set as NvMOTBatchMode_Batch
     pQuery->colorFormats[0] = NVBUF_COLOR_FORMAT_RGBA; // among {NVBUF_COLOR_FORMAT_NV12, NVBUF_COLOR_FORMAT_RGBA}
     pQuery->supportPastFrame = true;


### PR DESCRIPTION
1. 优化RGBA帧缓冲指针选择逻辑，优先mappedAddr，避免NVBUF_MEM_SURFACE_ARRAY下dataPtr不可用问题
2. 针对aarch64架构，设置memType为SURFACE_ARRAY，提升兼容性